### PR TITLE
Fix «Event handlers need a **kwargs for future proofing»

### DIFF
--- a/xontrib/z.py
+++ b/xontrib/z.py
@@ -206,7 +206,7 @@ class ZHandler:
 
 # FIXME: This should be pre-command, not on `cd`
 @events.on_chdir
-def cd_handler(olddir, newdir):
+def cd_handler(olddir, newdir, **kwargs):
     self = ZHandler()
     self.add(self.getpwd())
 


### PR DESCRIPTION
As indicated by this Trace when xonsh is run with `$XONSH_DEBUG=1`


    Traceback (most recent call last):
      File "/usr/lib/python3.6/site-packages/xonsh/proc.py", line 1304, in run
        r = self.f(self.args, sp_stdin, sp_stdout, sp_stderr, spec)
      File "/usr/lib/python3.6/site-packages/xonsh/proc.py", line 1144, in proxy_two
        return f(args, stdin)
      File "/usr/lib/python3.6/site-packages/xonsh/xontribs.py", line 169, in xontribs_main
        return _MAIN_XONTRIB_ACTIONS[ns.action](ns)
      File "/usr/lib/python3.6/site-packages/xonsh/xontribs.py", line 87, in _load
        update_context(name, ctx=ctx)
      File "/usr/lib/python3.6/site-packages/xonsh/xontribs.py", line 66, in update_context
        modctx = xontrib_context(name)
      File "/usr/lib/python3.6/site-packages/xonsh/xontribs.py", line 33, in xontrib_context
        m = importlib.import_module(spec.name)
      File "/usr/lib/python3.6/importlib/__init__.py", line 126, in import_module
        return _bootstrap._gcd_import(name[level:], package, level)
      File "<frozen importlib._bootstrap>", line 978, in _gcd_import
      File "<frozen importlib._bootstrap>", line 961, in _find_and_load
      File "<frozen importlib._bootstrap>", line 950, in _find_and_load_unlocked
      File "<frozen importlib._bootstrap>", line 655, in _load_unlocked
      File "<frozen importlib._bootstrap_external>", line 678, in exec_module
      File "<frozen importlib._bootstrap>", line 205, in _call_with_frames_removed
      File "/home/user/.local/lib/python3.6/site-packages/xontrib/z.py", line 208, in <module>
        @events.on_chdir
      File "/usr/lib/python3.6/site-packages/xonsh/events.py", line 70, in __call__
        raise ValueError("Event handlers need a **kwargs for future proofing")
    ValueError: Event handlers need a **kwargs for future proofing

Signed-off-by: Fabien Dubosson <fabien.dubosson@gmail.com>