### PR TITLE
Fix prog attr in argumentparser

### DIFF
--- a/xontrib/z.py
+++ b/xontrib/z.py
@@ -38,7 +38,7 @@ class ZHandler:
 
     def parser():
         from argparse import ArgumentParser
-        parser = ArgumentParser(prog='avox', description=__doc__)
+        parser = ArgumentParser(prog='z', description=__doc__)
 
         parser.add_argument('patterns', metavar='REGEX', nargs='+',
                             help='Names to match')


### PR DESCRIPTION
Looks like it was accidentally left intact when cloning from avox...