### PR TITLE
Change directory in the same thread

### DIFF
--- a/xontrib/z.py
+++ b/xontrib/z.py
@@ -166,7 +166,7 @@ class ZHandler:
             return "", "No matches found\n", 1
 
         if args.action == 'cd':
-            built_ins.run_subproc([['cd', data[0].path]])
+            built_ins.builtins.aliases['cd']([data[0].path])
         elif args.action == 'echo':
             return data[0].path + '\n'
         elif args.action == 'list':


### PR DESCRIPTION
This fixes an issue in xonsh with nested threads (see xonsh/xonsh#2504). This maintains compatibility with `autoxsh`.