### PR TITLE
Guard against corrupt data file

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,5 @@ xontrib load z
 ```
 
 in your `.xonshrc`
+The location of the data file is determined by setting an environment variable `_Z_DATA` 
+(default `~/.z` if not set).

--- a/xontrib/z.py
+++ b/xontrib/z.py
@@ -92,7 +92,7 @@ class ZHandler:
                     if r >= 1:
                         t = datetime.datetime.utcfromtimestamp(float(t))
                         yield ZEntry(p.replace('\\n','\n'), r, t)
-                except:
+                except Exception:
                     continue
 
     def save_data(self, data):

--- a/xontrib/z.py
+++ b/xontrib/z.py
@@ -94,11 +94,10 @@ class ZHandler:
                         r = int(r)
                     if r >= 1:
                         t = datetime.datetime.utcfromtimestamp(int(t))
+                        p = p.replace('\\n','\n').replace('\\|','|')
                         yield ZEntry(p, r, t)
                 except:
-                    continue  # skip entry if conversion fails 
-                    # (e.g. on unhandled special characters in path, faulty user edits,
-                    #  or corrupted data file)
+                    continue
 
     def save_data(self, data):
         # Age data
@@ -113,6 +112,7 @@ class ZHandler:
         with NamedTemporaryFile('wt', encoding=sys.getfilesystemencoding(),
                                 delete=False) as f:
             for e in data:
+                p = e.path.replace('\n','\\n').replace('|','\\|')
                 f.write("{}|{}|{}\n".format(e.path, int(e.rank), int(e.time.timestamp())))
             f.flush()
 

--- a/xontrib/z.py
+++ b/xontrib/z.py
@@ -10,7 +10,6 @@ import xonsh.lazyasd as lazyasd
 import xonsh.built_ins as built_ins
 
 __all__ = ()
-print(f'xotrib-z lodad {__file__}')
 
 class ZEntry(collections.namedtuple('ZEntry', ['path', 'rank', 'time'])):
     @property

--- a/xontrib/z.py
+++ b/xontrib/z.py
@@ -86,14 +86,19 @@ class ZHandler:
         with open(self.Z_DATA, 'rt') as f:
             for l in f:
                 l = l.strip()
-                p, r, t = l.split('|')
-                if '.' in r:
-                    r = float(r)
-                else:
-                    r = int(r)
-                if r >= 1:
-                    t = datetime.datetime.utcfromtimestamp(int(t))
-                    yield ZEntry(p, r, t)
+                try:
+                    p, r, t = l.split('|')
+                    if '.' in r:
+                        r = float(r)
+                    else:
+                        r = int(r)
+                    if r >= 1:
+                        t = datetime.datetime.utcfromtimestamp(int(t))
+                        yield ZEntry(p, r, t)
+                except:
+                    continue  # skip entry if conversion fails 
+                    # (e.g. on unhandled special characters in path, faulty user edits,
+                    #  or corrupted data file)
 
     def save_data(self, data):
         # Age data

--- a/xontrib/z.py
+++ b/xontrib/z.py
@@ -10,6 +10,7 @@ import xonsh.lazyasd as lazyasd
 import xonsh.built_ins as built_ins
 
 __all__ = ()
+print(f'xotrib-z lodad {__file__}')
 
 class ZEntry(collections.namedtuple('ZEntry', ['path', 'rank', 'time'])):
     @property
@@ -87,15 +88,11 @@ class ZHandler:
             for l in f:
                 l = l.strip()
                 try:
-                    p, r, t = l.split('|')
-                    if '.' in r:
-                        r = float(r)
-                    else:
-                        r = int(r)
+                    p, r, t = l.rsplit('|', 2)
+                    r = float(r)
                     if r >= 1:
-                        t = datetime.datetime.utcfromtimestamp(int(t))
-                        p = p.replace('\\n','\n').replace('\\|','|')
-                        yield ZEntry(p, r, t)
+                        t = datetime.datetime.utcfromtimestamp(float(t))
+                        yield ZEntry(p.replace('\\n','\n'), r, t)
                 except:
                     continue
 
@@ -112,8 +109,8 @@ class ZHandler:
         with NamedTemporaryFile('wt', encoding=sys.getfilesystemencoding(),
                                 delete=False) as f:
             for e in data:
-                p = e.path.replace('\n','\\n').replace('|','\\|')
-                f.write("{}|{}|{}\n".format(e.path, int(e.rank), int(e.time.timestamp())))
+                p = e.path.replace('\n','\\n')
+                f.write("{}|{}|{}\n".format(p, int(e.rank), int(e.time.timestamp())))
             f.flush()
 
             if self.Z_OWNER:


### PR DESCRIPTION
Works around corrupted data files that would otherwise throw an exception on every command execution entered in any xonsh shell that has xontrib-z activated.

This happened to me, when I changed dir into a folder that had a newline in it. The resulting data-file looked something like this:

```
/home/confus|425|1558040766
/home/confus/devel/suckless/st|58|1557794303
/tmp|29|1554672991
/tmp/data_is_
xs2|29|1554672999
/home|2|1553968033
/home/confus/.local/bin|4|1556291677
/home/confus/.local|1|1556298881
/home/confus/devel/suckless|3|1557707138
```

Note the superfuous linebreak in the 4th line after `/tmp/data_is_` and how the line continues with `xs2|29|1554672999`. Results in a traceback on **every** command executed in shell.

If I find the the time, I will modify the `save_data` and `load_data` function so it escapes resp. unescapes special characters. I think escaping the pipe `\|` and newline `\n` should be sufficient, but there might be other weird special cases like terminal bell, backspace and the like.