### PR TITLE
Option completion for `z` command

### DIFF
--- a/xontrib/z.py
+++ b/xontrib/z.py
@@ -206,6 +206,8 @@ class ZHandler:
 
     @classmethod
     def completer(cls, prefix, line, begidx, endidx, ctx):
+        if not line.lstrip().startswith('z '):
+            return {}
         opts = cls.parser._option_string_actions.keys()
         return {o for o in opts if o.startswith(prefix)}
 

--- a/xontrib/z.py
+++ b/xontrib/z.py
@@ -207,7 +207,7 @@ class ZHandler:
     @classmethod
     def completer(cls, prefix, line, begidx, endidx, ctx):
         if not line.lstrip().startswith('z '):
-            return {}
+            return set()
         opts = cls.parser._option_string_actions.keys()
         return {o for o in opts if o.startswith(prefix)}
 

--- a/xontrib/z.py
+++ b/xontrib/z.py
@@ -204,6 +204,10 @@ class ZHandler:
                 break
         self.save_data(data)
 
+    @classmethod
+    def completer(cls, prefix, line, begidx, endidx, ctx):
+        opts = cls.parser._option_string_actions.keys()
+        return {o for o in opts if o.startswith(prefix)}
 
     @classmethod
     def handler(cls, args, stdin=None):
@@ -215,3 +219,5 @@ def cmd_handler(**kwargs):
     self.add(self.getpwd())
 
 aliases['z'] = ZHandler.handler
+__xonsh__.completers['z'] = ZHandler.completer
+__xonsh__.completers.move_to_end('z', last=False)


### PR DESCRIPTION
Adds TAB-completion for the command line options to `z`:

![tab option completion for xontrib-z](https://user-images.githubusercontent.com/11145016/58087011-00457500-7bc0-11e9-8980-1707ec2b5e97.png)

**Note:** Does not overwrite completions coming from history. I.e. if one used `z html` in the past to navigate to `/var/www/html`, `html` will be included in the suggest.
